### PR TITLE
Add links to Table of Contents for Part-04

### DIFF
--- a/Lessons/Part-04-Collaborating-with-Remote-Repositories/collaborating-with-remote-repos.md
+++ b/Lessons/Part-04-Collaborating-with-Remote-Repositories/collaborating-with-remote-repos.md
@@ -1,11 +1,12 @@
 # Collaborating with Remote Repositories
 
-- Github
-- GitLab
-- Bitbucket
-- Pushing and Pulling Changes from remote repositories
-- Handling Merge Conflicts
-- Best Practices
+- [Setting up remote repositories (Github, GitLab, Bitbucket)](#setting-up-remote-repositories-github-gitlab-bitbucket)
+- [Github](#github)
+- [GitLab](#gitlab)
+- [Bitbucket](#bitbucket)
+- [Pushing and Pulling Changes from remote repositories](#pushing-and-pulling-changes-from-remote-repositories)
+- [Handling Merge Conflicts](#handling-merge-conflicts)
+- [Best Practices](#best-practices)
 
 ## Setting up remote repositories (GitHub, GitLab, Bitbucket)
 


### PR DESCRIPTION
Have solved issue https://github.com/rcallaby/Learn-Git/issues/84 and have added the required links to the table of contents. It navigates properly to respective sections upon clicking. 