### PR TITLE
Fix PR #147

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -5,7 +5,7 @@ on:
     - cron: "0 9 * * *"
 
 jobs:
-  check-links::
+  check-links:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Apologies @rcallaby , i didn't realize there was an additional `:` on one of the lines in the yml file. It would eventually fail as Github does not allow `:` in the name. I tested on old fork and it works without that extra `:`. 

